### PR TITLE
Update jails.conf to add IPV6 to ignoreip

### DIFF
--- a/conf/fail2ban/jails.conf
+++ b/conf/fail2ban/jails.conf
@@ -5,7 +5,7 @@
 # Whitelist our own IP addresses. 127.0.0.1/8 is the default. But our status checks
 # ping services over the public interface so we should whitelist that address of
 # ours too. The string is substituted during installation.
-ignoreip = 127.0.0.1/8 PUBLIC_IP
+ignoreip = 127.0.0.1/8 PUBLIC_IP ::1 PUBLIC_IPV6
 
 [dovecot]
 enabled = true

--- a/setup/system.sh
+++ b/setup/system.sh
@@ -356,6 +356,7 @@ systemctl restart systemd-resolved
 rm -f /etc/fail2ban/jail.local # we used to use this file but don't anymore
 rm -f /etc/fail2ban/jail.d/defaults-debian.conf # removes default config so we can manage all of fail2ban rules in one config
 cat conf/fail2ban/jails.conf \
+    | sed "s/PUBLIC_IPV6/$PUBLIC_IPV6/g" \
 	| sed "s/PUBLIC_IP/$PUBLIC_IP/g" \
 	| sed "s#STORAGE_ROOT#$STORAGE_ROOT#" \
 	> /etc/fail2ban/jail.d/mailinabox.conf


### PR DESCRIPTION
Update jails.conf to include IPV6 localhost and external ip to ignoreip line.  Update system.sh to include IPV6 address in replacement.  See mail-in-a-box#2066 for details.